### PR TITLE
Fix dedicated server crash caused by eager SpellTooltip loading

### DIFF
--- a/common/src/main/java/net/wizards/content/WizardSpells.java
+++ b/common/src/main/java/net/wizards/content/WizardSpells.java
@@ -538,7 +538,7 @@ public class WizardSpells {
     public static Entry arcane_barrage = add(arcane_barrage());
     private static Entry arcane_barrage() {
         var name = "Arcane Barrage";
-        var description = "Conjures " + SpellTooltip.placeholder(SpellTooltip.summonCountToken) + " Arcane Emitters behind you, firing at your target or where you aim. They last " + SpellTooltip.placeholder(SpellTooltip.summonDurationToken) + " sec and are empowered by your Arcane Spell Power.";
+        var description = "Conjures {summon_count} Arcane Emitters behind you, firing at your target or where you aim. They last {summon_duration} sec and are empowered by your Arcane Spell Power.";
         var id = Identifier.of(WizardsMod.ID, "arcane_barrage");
         var spell = SpellBuilder.createSpellActive();
         spell.school = SpellSchools.ARCANE;
@@ -1271,7 +1271,7 @@ public class WizardSpells {
     public static Entry fire_hydra = add(fire_hydra());
     private static Entry fire_hydra() {
         var name = "Fire Hydra";
-        var description = "Conjures a group of " + SpellTooltip.placeholder(SpellTooltip.summonCountToken) + " Fire Hydra heads near you, attacking nearby enemies. They last " + SpellTooltip.placeholder(SpellTooltip.summonDurationToken) + " sec and are empowered by your Fire Spell Power.";
+        var description = "Conjures a group of {summon_count} Fire Hydra heads near you, attacking nearby enemies. They last {summon_duration} sec and are empowered by your Fire Spell Power.";
         var id = Identifier.of(WizardsMod.ID, "fire_hydra");
         var spell = SpellBuilder.createSpellActive();
         spell.school = SpellSchools.FIRE;
@@ -1892,7 +1892,7 @@ public class WizardSpells {
     public static Entry frost_elemental = add(frost_elemental());
     private static Entry frost_elemental() {
         var name = "Frost Elemental";
-        var description = "Summons a Frost Elemental to fight by your side for " + SpellTooltip.placeholder(SpellTooltip.summonDurationToken) + " sec, empowered by your Frost Spell Power.";
+        var description = "Summons a Frost Elemental to fight by your side for {summon_duration} sec, empowered by your Frost Spell Power.";
         var id = Identifier.of(WizardsMod.ID, "frost_elemental");
         var spell = SpellBuilder.createSpellActive();
         spell.school = SpellSchools.FROST;


### PR DESCRIPTION
## Problem

Starting a dedicated server crashes during mod initialization:

```
java.lang.RuntimeException: Cannot load class net.minecraft.client.network.ClientPlayerEntity in environment type SERVER
    at knot/net.wizards.content.WizardSpells.arcane_barrage(WizardSpells.java:541)
    at knot/net.wizards.content.WizardSpells.<clinit>(WizardSpells.java:538)
```

`WizardSpells` builds the summon spell descriptions (`arcane_barrage`, `fire_hydra`, `frost_elemental`) by calling `SpellTooltip.placeholder(...)` during static initialization. `SpellTooltip` lives in Spell Engine's client package and references `MinecraftClient.player` (`ClientPlayerEntity`), so merely loading the class on a dedicated server throws. Since `WizardWeapons` touches `WizardSpells` during item registration, the whole server startup fails.

## Fix

Inline the literal `{summon_count}` / `{summon_duration}` placeholder tokens instead of calling `SpellTooltip.placeholder()`, matching the style already used for other tokens in this file (e.g. `{damage}`, `{teleport_distance}`). Since `placeholder(x)` just returns `"{" + x + "}"` and the token constants are compile-time-inlined strings, the resulting descriptions are byte-for-byte identical — tooltips and generated lang files are unaffected.

The remaining `SpellTooltip` references (the `DescriptionMutator` record component and the mutator lambda) are safe: type-only references don't trigger class loading, and the lambda body is only resolved when invoked client-side.

Tested: `:common:compileJava` passes; dedicated server starts normally with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LFdyAZFXxXc47kHi7iioE